### PR TITLE
refactor(declarations): Add more information and use scoped notations

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,25 @@ This produces information that pretty-prints each declaration in a module. The r
 {
    "name": "pow_two",
    "kind": "theorem",
-   "args": ["{M : Type u_2}", "[Monoid M]", "(a : M)"],
-   "type": "a ^ 2 = a * a",
+   "type": "∀ {M : Type u_2} [inst : Monoid M] (a : M), a ^ (2 : ℕ) = a * a",
+   "typeArgs": ["{M : Type u_2}", "[Monoid M]", "(a : M)"],
+   "typeBody": "a ^ (2 : ℕ) = a * a",
    "doc": "Note that most of the lemmas about powers of two refer to it as `sq`.",
-   "decl": "/-- Note that most of the lemmas about powers of two refer to it as `sq`. -/\ntheorem pow_two {M : Type u_2} [Monoid M] (a : M) : a ^ 2 = a * a",
-   "line": 810,
-   "column": 0
+   "signature": "/-- Note that most of the lemmas about powers of two refer to it as `sq`. -/\ntheorem pow_two {M : Type u_2} [Monoid M] (a : M) : a ^ (2 : ℕ) = a * a",
+   "module": "Mathlib.Algebra.Group.Defs",
+   "line": 602,
+   "column": 0,
+   "isProp": true,
+   "scope": "import Mathlib.Algebra.Notation.Defs\nimport Mathlib.Data.Int.Notation\nimport Mathlib.Data.Nat.BinaryRec\nimport Mathlib.Logic.Function.Defs\nimport Mathlib.Tactic.Simps.Basic\nimport Mathlib.Tactic.OfNat\nimport Batteries.Logic\n\nopen Function\n\nuniverse u v w\n\nvariable {G : Type*} {M : Type*} [Monoid M] {a b c : M}",
+   "src": "/-- Note that most of the lemmas about powers of two refer to it as `sq`. -/\n@[to_additive two_nsmul] lemma pow_two (a : M) : a ^ 2 = a * a := by rw [pow_succ, pow_one]",
+   "isHumanTheorem": true,
 }
 ```
+
+Ways to use the outputs are:
+- You may use `signature`, which is the pretty-printed version of the signature as it would show up under `#check` or Mathlib [docs](https://leanprover-community.github.io/mathlib4_docs/index.html). `signature` is built from the components `doc`, `kind`, `name`, `typeArgs`, and `typeBody`.
+- You may use `type`, which is a simpler version of the `typeArgs` and `typeBody` in `signature`. It is the format used in <https://leansearch.net>. The difference is that it does not try to introduce variables, etc. Under the hood, it uses `Meta.ppExpr type` instead of `PrettyPrinter.ppSignature name`.
+- You may use `scope` ++ `src`, which captures the declaration in the way it was written. `scope` includes the imports, namespace, open namespaces, variables, etc. at the declaration and `src` is the raw source of the declaration. For example, the `signature` of `add_comm` is `theorem add_comm ...` while the `src` is `@[to_additive] theorem mul_comm ...`. This field is useful for training a model to output source code.
 
 ### `imports`
 This outputs the imports of each module (both transitively imported modules and directly imported modules). The resulting format is

--- a/TrainingData/Frontend.lean
+++ b/TrainingData/Frontend.lean
@@ -87,6 +87,7 @@ structure CompilationStep where
   after : Environment
   msgs : List Message
   trees : List InfoTree
+  state : Frontend.State
 
 namespace CompilationStep
 
@@ -104,7 +105,8 @@ def one : FrontendM (CompilationStep × Bool) := do
   let after := s'.env
   let msgs := s'.messages.toList.drop s.messages.toList.length -- not using `msgs` for v4.8.0 support
   let trees := s'.infoState.trees.drop s.infoState.trees.size
-  return ({ src, stx, before, after, msgs, trees }, done)
+  let state ← getThe Frontend.State
+  return ({ src, stx, before, after, msgs, trees, state }, done)
 
 /-- Process all commands in the input. -/
 partial def all : FrontendM (List CompilationStep) := do

--- a/extract.sh
+++ b/extract.sh
@@ -7,7 +7,7 @@
 #SBATCH --error=logs/extract.out
 
 source /home/thomaszh/.bashrc
-cd /home/thomaszh/ntp-toolkit-hammer
+cd /home/thomaszh/ntp-toolkit-declarations2
 conda activate lm
 
 MAX_WORKERS=256 # set according to your RAM capacity

--- a/extract.sh
+++ b/extract.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
-#SBATCH --cpus-per-task=16
-#SBATCH --mem=128G
+#SBATCH --cpus-per-task=256
+#SBATCH --mem=1000G
 #SBATCH --time=48:00:00
 #SBATCH --output=logs/extract.out
 #SBATCH --error=logs/extract.out
@@ -10,7 +10,7 @@ source /home/thomaszh/.bashrc
 cd /home/thomaszh/ntp-toolkit-hammer
 conda activate lm
 
-MAX_WORKERS=16 # set according to your RAM capacity
+MAX_WORKERS=256 # set according to your RAM capacity
 CONFIG=configs/config_mathlib_full.json
 rm -rf Examples/mathlib
 python scripts/extract_repos.py --config $CONFIG --cwd "`pwd`" --imports --max-workers $MAX_WORKERS

--- a/extract.sh
+++ b/extract.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 #SBATCH --cpus-per-task=256
-#SBATCH --mem=1000G
+#SBATCH --mem=512G
 #SBATCH --time=48:00:00
 #SBATCH --output=logs/extract.out
 #SBATCH --error=logs/extract.out

--- a/extract.sh
+++ b/extract.sh
@@ -21,7 +21,7 @@ python scripts/extract_repos.py --config $CONFIG --cwd "`pwd`" --add_imports --s
 lake exe update_hammer_blacklist > Examples/mathlib/HammerBlacklist.jsonl
 python scripts/get_config_revision.py --config $CONFIG > Examples/mathlib/revision
 
-OUTPUT_DIR=/data/user_data/thomaszh
-
-rm -rf $OUTPUT_DIR/mathlib
+OUTPUT_DIR=/data/user_data/thomaszh/declarations2/mathlib
+mkdir -p $OUTPUT_DIR
+rm -rf $OUTPUT_DIR
 cp -r Examples/mathlib $OUTPUT_DIR

--- a/scripts/declarations.lean
+++ b/scripts/declarations.lean
@@ -119,7 +119,7 @@ def compilationStepToJson (step : CompilationStep) : CoreM Json := do
 
   let savedState ← saveState
   resetMessageLog
-  liftCommandElabM do
+  liftCommandElabM (throwOnError := false) do
     set state.commandState
     Command.elabWhere (← `(command| #where))
   let messages ← getAndEmptyMessageLog

--- a/scripts/declarations.lean
+++ b/scripts/declarations.lean
@@ -3,7 +3,7 @@ import Mathlib.Control.Basic
 import Mathlib.Lean.Expr.Basic
 import Batteries
 import TrainingData.Utils.TheoremPrettyPrinting
-import TrainingData.Utils.WithImports
+import TrainingData.Frontend
 
 /-!
 Generate name, type, docstring, and pretty-printed information for each declaration in a module.
@@ -13,11 +13,11 @@ This uses doc-gen4 and outputs approximately the same format as doc-gen4.
 The extracted declarations are usually used as potential premises to select from for a premise retriever.
 -/
 
-open Lean Meta DocGen4.Process
+open Lean Elab IO Meta DocGen4.Process
 
 namespace DocGen4.Process
 
-open DocGen4 DocGen4.Process DocGen4.Process.DocInfo TheoremPrettyPrinting
+open DocInfo TheoremPrettyPrinting
 
 /--
 Returns kind (string) and Info given constant.
@@ -71,11 +71,11 @@ def Lean.Name.isHumanTheorem (name : Name) : CoreM Bool := do
   return hasDeclRange && isTheorem && notProjFn
 
 /-- Pretty-prints a constant to JSON -/
-def constantInfoToJson (cinfo : ConstantInfo) : MetaM Json := do
+def constantInfoToJson (cinfo : ConstantInfo) (step : CompilationStep) : MetaM Json := do
   let (kind, info) ← infoOfConstant cinfo
   let name := cinfo.name.toString
   let args := info.args.map (fun arg => arg.binder.stripTags)
-  let type := info.type.stripTags
+  let typeBody := info.type.stripTags
   let doc? := info.doc
 
   -- format declaration into `decl`
@@ -86,13 +86,17 @@ def constantInfoToJson (cinfo : ConstantInfo) : MetaM Json := do
   decl := decl ++ name ++ " "
   for arg in args do
     decl := decl ++ arg ++ " "
-  decl := decl ++ ": " ++ type
+  decl := decl ++ ": " ++ typeBody
+
+  let type ← ppExpr cinfo.type
+  let type := type.pretty 100000000000000
 
   return Json.mkObj [
     ("name", Json.str name),
     ("kind", Json.str kind),
-    ("args", Json.arr (args.map .str)),
     ("type", Json.str type),
+    ("typeArgs", Json.arr (args.map .str)),
+    ("typeBody", Json.str typeBody),
     ("doc", match doc? with
       | some doc => Json.str doc
       | none => Json.null),
@@ -100,8 +104,38 @@ def constantInfoToJson (cinfo : ConstantInfo) : MetaM Json := do
     ("line", Json.num info.declarationRange.pos.line),
     ("column", Json.num info.declarationRange.pos.column),
     ("isProp", Json.bool (← isProp cinfo.type)),
+    ("src", Json.str step.src.toString),
+    ("module", Json.str step.after.mainModule.toString),
     -- Only certain declarations can be in the eval/test set
     ("isHumanTheorem", Json.bool (← Name.isHumanTheorem cinfo.name)),
+  ]
+
+open Core in
+/-- Delaborates the current scope using `#where`. -/
+def frontendStateToJson (state : Frontend.State) : CoreM Json := do
+  let imports := state.commandState.env.header.imports.toList
+  let mut importsStr := ""
+  if imports.all (·.module != `Init) then importsStr := importsStr ++ "prelude\n"
+  for imp in imports do
+    unless imp.module == `Init do
+      importsStr := importsStr ++ s!"import {imp.module}\n"
+
+  let savedState ← saveState
+  resetMessageLog
+  liftCommandElabM do
+    set state.commandState
+    Command.elabWhere (← `(command| #where))
+  let messages ← getAndEmptyMessageLog
+  let scopeStr? ← messages.toArray.findSomeRevM? fun msg => do
+    if msg.severity == MessageSeverity.information then
+      return some <| (← msg.toString).replace "-- In root namespace with initial scope" "" |>.trim
+    else
+      return none
+  savedState.restore
+
+  let scopeStr := (importsStr.trim ++ "\n\n" ++ (scopeStr?.getD "").trim).trim
+  return Json.mkObj [
+    ("scope", Json.str scopeStr),
   ]
 
 /-- If a constant should not be included (more permissive than Name.isBlackListed). -/
@@ -109,42 +143,39 @@ def isBlackListedName (name : Name) : Bool :=
   name == ``sorryAx || name.isInternalDetail
 
 /--
-Traverse all declarations from modules, collecting prettified declarations
+Process all declarations from compilation steps, collecting prettified declarations.
 Calls callback on each extracted declaration.
-(Should convert to MLList instead of callback?)
 -/
-def allDeclarations (moduleNames : Array Name) (callback : Nat → Nat → Name → Json → MetaM Unit) :
-    MetaM Unit := do
-  let env ← getEnv
-  let constantsMap := env.constants.map₁
-  let total := constantsMap.size
-  let mut i := 0
-  for (name, cinfo) in constantsMap do
-    if !isBlackListedName name then
-      if let some moduleIdx := env.getModuleIdxFor? name then
-        if let some moduleName := env.header.moduleNames[moduleIdx.toNat]? then
-          if moduleNames.contains moduleName then
-            try
-              let json ← constantInfoToJson cinfo
-              callback i total name json
-            catch _ =>
-              -- Extremely rare cases (e.g. Fin.eq_of_val_eq, Qq.Quoted.unsafeMk)
-              IO.eprintln s!"warning: failed to extract constant {name}"
-              continue
-    i := i + 1
+def allDeclarationsFromSteps (compilationSteps : List CompilationStep) (callback : Nat → Name → Json → MetaM Unit) :
+    IO Unit := do
+  let mut processed := 0
+  for step in compilationSteps do
+    for cinfo in step.diff do
+      if isBlackListedName cinfo.name then continue
+      let ctxCore : Core.Context := { fileName := "<ntp-toolkit>", fileMap := default, maxHeartbeats := 0 }
+      let sCore : Core.State := { env := step.after }
+      let _ ← MetaM.toIO (ctxCore := ctxCore) (sCore := sCore) (ctx := {}) (s := {}) do
+        try
+          let json ← constantInfoToJson cinfo step
+          let json' ← frontendStateToJson step.state
+          let json := json.mergeObj json'
+          callback processed cinfo.name json
+        catch _ =>
+          -- Extremely rare cases (e.g. Fin.eq_of_val_eq, Qq.Quoted.unsafeMk)
+          IO.eprintln s!"warning: failed to extract constant {cinfo.name}"
+      processed := processed + 1
 
 def main (args : List String) : IO UInt32 := do
+  unsafe enableInitializersExecution
+  initSearchPath (← findSysroot)
+
   let modules := match args with
   | [] => #[`Mathlib]
-  | args => args.toArray.map fun s => s.toName
-  -- Proper delaborators need also be loaded for better printing of results
-  -- (e.g., if the module is Init.Prelude which does not have delaborator for Eq yet)
-  let delaboratorModules := #[
-  ]
-  let importModules := modules ++ delaboratorModules
-  MetaM.withImportModules' importModules do
-    allDeclarations modules fun _ _ _ json ↦ do
-      -- IO.eprint s!"\x1B[2K\rProcessing [{i}/{total}] {name.toString.take 60}"
+  | args => args.toArray.map fun s : String => s.toName
+
+  -- Process each module using compilation steps
+  for module in modules do
+    let compilationSteps ← compileModule module
+    allDeclarationsFromSteps compilationSteps fun _ _ json ↦ do
       IO.println json.compress
-    -- IO.eprintln ""
   return 0


### PR DESCRIPTION
Previously declarations used something similar to doc-gen4, which is to import the module and look at the resulting declared constants. Now it directly runs the module and outputs declared constant(s) for each command. This allows us to:

* Print declarations with the scoped notation in the scope they are declared in
* Print the scope (currently imports + output of `#where`)
* Print the raw string that defines this constant

Test: this loses 29 premises from all of Mathlib, including `Fin.eq_of_val_eq` in `Init.Prelude`, `Algebra.TensorProduct.tensorTensorTensorComm_symm` in `Mathlib.RingTheory.TensorProduct.Basic` (TODO: why?). I am inclined to ignore these for now.